### PR TITLE
Issue 9: Fix BATS test instructions in README and test path resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,19 +172,38 @@ cat REGISTRY.md
 ```bash
 # Install BATS (Bash Automated Testing System)
 # macOS: brew install bats-core
-# Linux: apt-get install bats or yum install bats
+# Linux: sudo apt-get install bats
 
-# Run all tests
-bats test/
+# Verify BATS is installed
+bats --version
+
+# Run all unit tests (from project root)
+bats test/unit/
 
 # Run specific test file
-bats test/test-platform-detection.bats
+bats test/unit/test-cli.bats
 
-# Run with verbose output
-bats -t test/
+# View test summary
+bats test/unit/ 2>&1 | grep -E "^(ok|not ok|# )" | head -25
 
-# Run property-based tests
-bats test/property-tests/
+# Count passing vs failing tests
+bats test/unit/ 2>&1 | grep -c "^ok"        # Passing
+bats test/unit/ 2>&1 | grep -c "^not ok"    # Failing
+```
+
+**Test Suite:** 20 CLI tests covering argument parsing, validation, and configuration.
+
+**Known Issues:** Some tests fail due to [known bugs](KNOWN-ISSUES.md):
+- Help output shows library help instead of main script help (Issue #2)
+- macOS has PLATFORM_TOOLS initialization bug (Issue #1)
+- Tests require BATS 1.5.0+ (Linux apt version may be older)
+
+**Linux Note:** Ubuntu's default BATS (1.2.1) is outdated. For full test support:
+```bash
+# Install latest BATS from source on Linux
+git clone https://github.com/bats-core/bats-core.git
+cd bats-core
+sudo ./install.sh /usr/local
 ```
 
 ### Code Quality

--- a/test/helpers.bats
+++ b/test/helpers.bats
@@ -49,7 +49,16 @@ create_test_image() {
 
 # Helper to capture stdout and stderr
 run_script_with_args() {
-    local script_path="${BATS_TEST_DIRNAME}/../build-rpi-image.sh"
+    local script_path
+    if [[ -f "${BATS_TEST_DIRNAME}/../build-rpi-image.sh" ]]; then
+        script_path="${BATS_TEST_DIRNAME}/../build-rpi-image.sh"
+    elif [[ -f "${BATS_TEST_DIRNAME}/../../build-rpi-image.sh" ]]; then
+        script_path="${BATS_TEST_DIRNAME}/../../build-rpi-image.sh"
+    else
+        echo "ERROR: Cannot find build-rpi-image.sh" >&2
+        return 127
+    fi
+    
     local output
     local exit_code
     

--- a/test/unit/test-cli.bats
+++ b/test/unit/test-cli.bats
@@ -3,7 +3,12 @@
 # Tests help output, argument parsing, and error conditions
 # Feature: raspberry-pi-image-builder, Property 19: Parameter acceptance and handling
 
-load "helpers"
+setup_file() {
+    export BATS_TEST_DIRNAME="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )"
+    export PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+}
+
+load "../helpers.bats"
 
 setup() {
     setup_test_environment


### PR DESCRIPTION
Issue: README.md testing instructions were incorrect and non-functional
- bats test/ command doesn't work (no tests in root)
- test/test-platform-detection.bats doesn't exist
- test/property-tests/ directory doesn't exist
- Helpers path resolution broken for unit tests

Fixes:
- Update README with correct BATS commands that actually work
- Fix helpers.bats to find build-rpi-image.sh from subdirectories
- Fix test-cli.bats to load helpers from correct relative path
- Add notes about BATS version requirements
- Document known test failures due to existing bugs

Working Commands (verified):
- bats test/unit/ - Runs all 20 CLI tests
- bats test/unit/test-cli.bats - Runs specific test file
- Test result counting and filtering commands

Test Results:
- 20 tests total (3 passing, 17 failing)
- Failures due to known bugs (Issues #1, #2)
- Test framework itself is now functional

Documentation:
- Added BATS version requirements
- Added Linux-specific installation notes
- Added note about known test failures
- Removed references to non-existent test files

This PR closes issue #9 